### PR TITLE
news.adobe.com to hlx-5

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -19,10 +19,10 @@ export const [setLibs, getLibs] = (() => {
     (prodLibs, location) => {
       libs = (() => {
         const { hostname, search } = location || window.location;
-        if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return prodLibs;
+        if (!(hostname.includes('.hlx.') || hostname.includes('.aem') || hostname.includes('local'))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
         if (branch === 'local') return 'http://localhost:6456/libs';
-        return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;
+        return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;
       })();
       return libs;
     }, () => libs,

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -4,7 +4,7 @@ import { setLibs } from '../../scripts/utils.js';
 describe('Libs', () => {
   it('Default Libs', () => {
     const libs = setLibs('/libs');
-    expect(libs).to.equal('https://main--milo--adobecom.hlx.live/libs');
+    expect(libs).to.equal('https://main--milo--adobecom.aem.live/libs');
   });
 
   it('Does not support milolibs query param on prod', () => {
@@ -22,7 +22,7 @@ describe('Libs', () => {
       search: '?milolibs=foo',
     };
     const libs = setLibs('/libs', location);
-    expect(libs).to.equal('https://foo--milo--adobecom.hlx.live/libs');
+    expect(libs).to.equal('https://foo--milo--adobecom.aem.live/libs');
   });
 
   it('Supports local milolibs query param', () => {
@@ -40,6 +40,6 @@ describe('Libs', () => {
       search: '?milolibs=awesome--milo--forkedowner',
     };
     const libs = setLibs('/libs', location);
-    expect(libs).to.equal('https://awesome--milo--forkedowner.hlx.live/libs');
+    expect(libs).to.equal('https://awesome--milo--forkedowner.aem.live/libs');
   });
 });

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -3,9 +3,9 @@
     {
       "id": "library",
       "title": "Library",
-      "environments": [
-        "edit"
-      ],
+      "previewHost": "main--news--adobecom.aem.page",
+      "liveHost": "main--news--adobecom.aem.live",
+      "environments": [ "edit" ],
       "isPalette": true,
       "passConfig": true,
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
@@ -24,7 +24,7 @@
       "id": "localize",
       "title": "Localize",
       "environments": [ "edit" ],
-      "url": "https://main--milo--adobecom.hlx.page/tools/loc/index.html?project=news--adobecom",
+      "url": "https://main--milo--adobecom.aem.page/tools/loc/index.html?project=news--adobecom",
       "passReferrer": true,
       "includePaths": [ "**/:x**" ]
     },
@@ -33,7 +33,7 @@
       "id": "localize-2",
       "title": "Localize (V2)",
       "environments": [ "edit" ],
-      "url": "https://main--news--adobecom.hlx.page/tools/loc?milolibs=locui",
+      "url": "https://main--news--adobecom.aem.page/tools/loc?milolibs=locui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]


### PR DESCRIPTION
### Description 
*Upgrading to aem.live from hlx.live* as per the product requirements and [docs](https://www.aem.live/developer/upgrade).
This is not meant to be a complete PR but a spike to ensure you have everything you need and should be carefully QA'd

### Todo's
1. This will need proper QA
2. This will need to get merged
3. This will need an origin swap on the akamai level to consume `aem.page` and `aem.live` 
4. Once we switched the origin, we can delete references to `hlx.live` or `hlx.page`


### Test URLs
All 4 variations should work: `hlx.page` `aem.page` `hlx.live` `aem.live`

**Test URLs:**
- Before: https://main--news--adobecom.hlx.live/?martech=off
- After-1: https://hlx5--news--adobecom.hlx.live/?martech=off
- After-2: https://hlx5--news--adobecom.aem.live/?martech=off