### PR TITLE
MWPW-146930 - Rollout tool plugin

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -104,6 +104,18 @@
       "url": "https://milo.adobe.com/tools/caas",
       "isPalette": false,
       "includePaths": [ "**.docx**"]
+    },
+    {
+      "containerId": "tools",
+      "id": "rollout",
+      "title": "Rollout",
+      "environments": [ "preview" ],
+      "isPalette": true,
+      "passReferrer": true,
+      "passConfig": true,
+      "url": "https://milo.adobe.com/tools/rollout",
+      "includePaths": [ "**.docx**", "**.xlsx**" ],
+      "paletteRect": "top: 40%; left: 50%; transform: translate(-50%,-50%); height: 350px; width: 500px; overflow: hidden; border-radius: 15px; box-shadow: 0 20px 35px 0px rgba(0, 0, 0, 0.5);"
     }
   ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,5 +1,5 @@
 {
-  "project": "Adobe News",
+  "project": "news",
   "plugins": [
     {
       "id": "library",

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,4 +1,5 @@
 {
+  "project": "Adobe News",
   "plugins": [
     {
       "id": "library",


### PR DESCRIPTION
MWPW-146930 - Rollout tool plugin
Adding option in sidekick to rollout files directly to geos. This plugin will do some basic calculation and form a url. On selection of the environment, the user will be taken to the Loc V3 project config page with some options (sent as part of the parameter) pre-selected.

Resolves: [MWPW-146930](https://jira.corp.adobe.com/browse/MWPW-146930)

**Test URLs:**
- Before: https://main--news--adobecom.hlx.page/news/2025/1/adi-pr-full-season-recap?martech=off
- After: https://rollout--news--raga-adbe-gh.hlx.page/news/2025/1/adi-pr-full-season-recap?martech=off